### PR TITLE
notekit: fully-qualify non-core dependency

### DIFF
--- a/Formula/notekit.rb
+++ b/Formula/notekit.rb
@@ -9,7 +9,7 @@ class Notekit < Formula
   depends_on "pkg-config" => :build
 
   depends_on "adwaita-icon-theme"
-  depends_on "clatexmath"
+  depends_on "sp1ritCS/tap/clatexmath"
   depends_on "fontconfig"
   depends_on "gtkmm3"
   depends_on "gtksourceviewmm3"


### PR DESCRIPTION
Otherwise, anyone using your tap will install `clatexmath` from the first tap that contains a formula with that name, which may not be what your own formula needs.